### PR TITLE
Remove a `fatalError()` in ConformanceDescriptor.swift

### DIFF
--- a/Sources/Echo/Runtime/ConformanceDescriptor.swift
+++ b/Sources/Echo/Runtime/ConformanceDescriptor.swift
@@ -64,7 +64,9 @@ public struct ConformanceDescriptor: LayoutWrapper {
         .assumingMemoryBound(to: CChar.self)
       
       guard let anyClass = objc_lookUpClass(ptr) else {
-        fatalError("No Objective-C class named \(ptr.string)")
+        // A conformance with a nil class means the class was weak-linked
+        // from a newer SDK and isn't available in this version of iOS 
+        return nil
       }
       
       return reflect(anyClass) as? ObjCClassWrapperMetadata


### PR DESCRIPTION
A conformance's class will be nil when the conformance refers to a class that is only present in a newer SDK. For example, SDKAdImpression is only available on iOS 14.5. An app that uses SDKAdImpression would wrap it in `if @available` guards. While the conformance and class name is still present in the binary when it runs on iOS < 14.5, the class will be `nil`, and the app will crash when Echo is loaded.